### PR TITLE
feat: compressor can use past data for better perf + settings -> Header

### DIFF
--- a/lzss/backref.go
+++ b/lzss/backref.go
@@ -47,6 +47,8 @@ type backref struct {
 	bType   BackrefType
 }
 
+// Warning; writeTo and readFrom are not symmetrical
+
 func (b *backref) writeTo(w *bitio.Writer, i int) {
 	w.TryWriteByte(b.bType.Delimiter)
 	w.TryWriteBits(uint64(b.length-1), b.bType.NbBitsLength)

--- a/lzss/compress.go
+++ b/lzss/compress.go
@@ -104,9 +104,9 @@ func InitBackRefTypes(dictLen int, level Level) (short, long, dict BackrefType) 
 // hint should be a subset of the data compressed by the same compressor
 // For example, calling Compress([]byte{1, 2, 3, 4, 5}, compressed([]byte{1, 2, 3})) will
 // result in much faster compression than calling Compress([]byte{1, 2, 3, 4, 5})
-func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err error) {
+func (compressor *Compressor) Compress(input []byte, hints ...[]byte) (c []byte, err error) {
 	// check input size
-	if len(d) > MaxInputSize {
+	if len(input) > MaxInputSize {
 		return nil, fmt.Errorf("input size must be <= %d", MaxInputSize)
 	}
 
@@ -121,7 +121,7 @@ func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err
 
 	// write uncompressed data if compression is disabled
 	if compressor.level == NoCompression {
-		compressor.buf.Write(d)
+		compressor.buf.Write(input)
 		return compressor.buf.Bytes(), nil
 	}
 
@@ -133,20 +133,20 @@ func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err
 	if len(hints) == 1 {
 		// try to compress from the hint to save time (no need to look for optimal backrefs
 		// if we already have a good enough hint)
-		startI = compressor.compressFromHint(header, d, hints[0])
+		startI = compressor.compressFromHint(header, input, hints[0])
 	}
 
 	// build the index
-	compressor.inputIndex = suffixarray.New(d, compressor.inputSa[:len(d)])
+	compressor.inputIndex = suffixarray.New(input, compressor.inputSa[:len(input)])
 
 	bDict := backref{bType: dictBackRefType, length: -1, address: -1}
 	bShort := backref{bType: shortBackRefType, length: -1, address: -1}
 	bLong := backref{bType: longBackRefType, length: -1, address: -1}
 
 	fillBackrefs := func(i int, minLen int) bool {
-		bDict.address, bDict.length = compressor.findBackRef(d, i, dictBackRefType, minLen)
-		bShort.address, bShort.length = compressor.findBackRef(d, i, shortBackRefType, minLen)
-		bLong.address, bLong.length = compressor.findBackRef(d, i, longBackRefType, minLen)
+		bDict.address, bDict.length = compressor.findBackRef(input, i, dictBackRefType, minLen)
+		bShort.address, bShort.length = compressor.findBackRef(input, i, shortBackRefType, minLen)
+		bLong.address, bLong.length = compressor.findBackRef(input, i, longBackRefType, minLen)
 		return !(bDict.length == -1 && bShort.length == -1 && bLong.length == -1)
 	}
 	bestBackref := func() (backref, int) {
@@ -159,8 +159,8 @@ func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err
 		return bLong, bLong.savings()
 	}
 
-	for i := startI; i < len(d); {
-		if !canEncodeSymbol(d[i]) {
+	for i := startI; i < len(input); {
+		if !canEncodeSymbol(input[i]) {
 			// we must find a backref.
 			if !fillBackrefs(i, 1) {
 				// we didn't find a backref but can't write the symbol directly
@@ -173,17 +173,17 @@ func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err
 		}
 		if !fillBackrefs(i, -1) {
 			// we didn't find a backref, let's write the symbol directly
-			compressor.writeByte(d[i])
+			compressor.writeByte(input[i])
 			i++
 			continue
 		}
 		bestAtI, bestSavings := bestBackref()
 
-		if i+1 < len(d) {
+		if i+1 < len(input) {
 			if fillBackrefs(i+1, bestAtI.length+1) {
 				if newBest, newSavings := bestBackref(); newSavings > bestSavings {
 					// we found a better backref at i+1
-					compressor.writeByte(d[i])
+					compressor.writeByte(input[i])
 					i++
 
 					// then mark backref to be written at i+1
@@ -191,11 +191,11 @@ func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err
 					bestAtI = newBest
 
 					// can we find an even better backref at i+2 ?
-					if canEncodeSymbol(d[i]) && i+1 < len(d) {
+					if canEncodeSymbol(input[i]) && i+1 < len(input) {
 						if fillBackrefs(i+1, bestAtI.length+1) {
 							// we found an even better backref
 							if newBest, newSavings := bestBackref(); newSavings > bestSavings {
-								compressor.writeByte(d[i])
+								compressor.writeByte(input[i])
 								i++
 
 								bestAtI = newBest
@@ -203,15 +203,15 @@ func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err
 						}
 					}
 				}
-			} else if i+2 < len(d) && canEncodeSymbol(d[i+1]) {
+			} else if i+2 < len(input) && canEncodeSymbol(input[i+1]) {
 				// maybe at i+2 ? (we already tried i+1)
 				if fillBackrefs(i+2, bestAtI.length+2) {
 					if newBest, newSavings := bestBackref(); newSavings > bestSavings {
 						// we found a better backref
 						// write the symbol at i
-						compressor.writeByte(d[i])
+						compressor.writeByte(input[i])
 						i++
-						compressor.writeByte(d[i])
+						compressor.writeByte(input[i])
 						i++
 
 						// then emit the backref at i+2
@@ -232,14 +232,14 @@ func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err
 		return nil, err
 	}
 
-	if compressor.buf.Len() >= len(d)+bitLen/8 {
+	if compressor.buf.Len() >= len(input)+bitLen/8 {
 		// compression was not worth it
 		compressor.buf.Reset()
 		header.Level = NoCompression
 		if _, err = header.WriteTo(&compressor.buf); err != nil {
 			return
 		}
-		_, err = compressor.buf.Write(d)
+		_, err = compressor.buf.Write(input)
 	}
 
 	return compressor.buf.Bytes(), err

--- a/lzss/decompress.go
+++ b/lzss/decompress.go
@@ -14,30 +14,34 @@ import (
 // Note that this is not a fail-safe decompressor, it will fail ungracefully if the data
 // has a different format than the one expected
 func Decompress(data, dict []byte) (d []byte, err error) {
-	var out bytes.Buffer
-	out.Grow(len(data)*6 + len(dict))
 	in := bitio.NewReader(bytes.NewReader(data))
 
-	var settings settings
-	if err = settings.readFrom(in); err != nil {
+	// parse header
+	var header Header
+	sizeHeader, err := header.ReadFrom(in)
+	if err != nil {
 		return
 	}
-	if settings.version != 0 {
+	if header.Version != Version {
 		return nil, errors.New("unsupported compressor version")
 	}
-	if settings.level == NoCompression {
-		return data[2:], nil
+	if header.Level == NoCompression {
+		return data[sizeHeader:], nil
 	}
 
+	// init dict and backref types
 	dict = AugmentDict(dict)
-	shortBackRefType, longBackRefType, dictBackRefType := InitBackRefTypes(len(dict), settings.level)
+	shortBackRefType, longBackRefType, dictBackRefType := InitBackRefTypes(len(dict), header.Level)
 
 	bDict := backref{bType: dictBackRefType}
 	bShort := backref{bType: shortBackRefType}
 	bLong := backref{bType: longBackRefType}
 
-	// read until startAt and write bytes as is
+	var out bytes.Buffer
+	out.Grow(len(data)*6 + len(dict))
 
+	// read byte per byte; if it's a backref, write the corresponding bytes
+	// otherwise, write the byte as is
 	s := in.TryReadByte()
 	for in.TryError == nil {
 		switch s {
@@ -78,19 +82,19 @@ func ReadIntoStream(data, dict []byte, level Level) (compress.Stream, error) {
 	// now find out how much of the stream is padded zeros and remove them
 	in := bitio.NewReader(bytes.NewReader(data))
 	dict = AugmentDict(dict)
-	var settings settings
-	if err := settings.readFrom(in); err != nil {
+	var header Header
+	if _, err := header.ReadFrom(in); err != nil {
 		return out, err
 	}
 	shortBackRefType, longBackRefType, dictBackRefType := InitBackRefTypes(len(dict), level)
 
 	// the main job of this function is to compute the right value for outLenBits
 	// so we can remove the extra zeros at the end of out
-	outLenBits := settings.bitLen()
-	if settings.level == NoCompression {
+	outLenBits := bitLen
+	if header.Level == NoCompression {
 		return out, nil
 	}
-	if settings.level != level {
+	if header.Level != level {
 		return out, errors.New("compression mode mismatch")
 	}
 

--- a/lzss/decompress.go
+++ b/lzss/decompress.go
@@ -38,7 +38,7 @@ func Decompress(data, dict []byte) (d []byte, err error) {
 	bLong := backref{bType: longBackRefType}
 
 	var out bytes.Buffer
-	out.Grow(len(data)*6 + len(dict))
+	out.Grow(len(data) * 7)
 
 	// read byte per byte; if it's a backref, write the corresponding bytes
 	// otherwise, write the byte as is

--- a/lzss/header.go
+++ b/lzss/header.go
@@ -2,9 +2,7 @@ package lzss
 
 import (
 	"encoding/binary"
-	"errors"
 	"io"
-	"math"
 )
 
 const (
@@ -15,50 +13,33 @@ const (
 // Header is the header of a compressed data.
 // It contains the compressor release version and the compression level.
 type Header struct {
-	Version byte   // compressor release version
+	Version uint16 // compressor release version
 	Level   Level  // compression level
-	Extra   []byte // "extra data", max len == math.MaxUint16
+	// A future version may add more fields here, so we'll have to read the
+	// version first, then read the rest of the header based on the version.
+	// Extra   []byte // "extra data", max len == math.MaxUint16
 }
 
 func (s *Header) WriteTo(w io.Writer) (int64, error) {
-	l := len(s.Extra)
-	if l > math.MaxUint16 {
-		return 0, errors.New("extra data too long")
-	}
-
-	if _, err := w.Write([]byte{s.Version, byte(s.Level)}); err != nil {
+	if err := binary.Write(w, binary.LittleEndian, uint16(s.Version)); err != nil {
 		return 0, err
 	}
 
-	if err := binary.Write(w, binary.LittleEndian, uint16(l)); err != nil {
+	if _, err := w.Write([]byte{byte(s.Level)}); err != nil {
 		return 2, err
 	}
-	if l > 0 {
-		if _, err := w.Write(s.Extra); err != nil {
-			return 4, err
-		}
-	}
 
-	return 4 + int64(l), nil
+	return 3, nil
 }
 
 func (s *Header) ReadFrom(r io.Reader) (int64, error) {
-	var b [4]byte
+	var b [3]byte
 	n, err := io.ReadFull(r, b[:])
 	if err != nil {
 		return int64(n), err
 	}
 
-	s.Version = b[0]
-	s.Level = Level(b[1])
-	l := binary.LittleEndian.Uint16(b[2:])
-	if l > 0 {
-		s.Extra = make([]byte, l)
-		n2, err := io.ReadFull(r, s.Extra)
-		n += int(n2)
-		if err != nil {
-			return int64(n), err
-		}
-	}
+	s.Version = binary.LittleEndian.Uint16(b[:2])
+	s.Level = Level(b[2])
 	return int64(n), nil
 }

--- a/lzss/header.go
+++ b/lzss/header.go
@@ -1,0 +1,64 @@
+package lzss
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"math"
+)
+
+const (
+	// Version is the current release version of the compressor.
+	Version = 0
+)
+
+// Header is the header of a compressed data.
+// It contains the compressor release version and the compression level.
+type Header struct {
+	Version byte   // compressor release version
+	Level   Level  // compression level
+	Extra   []byte // "extra data", max len == math.MaxUint16
+}
+
+func (s *Header) WriteTo(w io.Writer) (int64, error) {
+	l := len(s.Extra)
+	if l > math.MaxUint16 {
+		return 0, errors.New("extra data too long")
+	}
+
+	if _, err := w.Write([]byte{s.Version, byte(s.Level)}); err != nil {
+		return 0, err
+	}
+
+	if err := binary.Write(w, binary.LittleEndian, uint16(l)); err != nil {
+		return 2, err
+	}
+	if l > 0 {
+		if _, err := w.Write(s.Extra); err != nil {
+			return 4, err
+		}
+	}
+
+	return 4 + int64(l), nil
+}
+
+func (s *Header) ReadFrom(r io.Reader) (int64, error) {
+	var b [4]byte
+	n, err := io.ReadFull(r, b[:])
+	if err != nil {
+		return int64(n), err
+	}
+
+	s.Version = b[0]
+	s.Level = Level(b[1])
+	l := binary.LittleEndian.Uint16(b[2:])
+	if l > 0 {
+		s.Extra = make([]byte, l)
+		n2, err := io.ReadFull(r, s.Extra)
+		n += int(n2)
+		if err != nil {
+			return int64(n), err
+		}
+	}
+	return int64(n), nil
+}

--- a/lzss/header_test.go
+++ b/lzss/header_test.go
@@ -1,0 +1,27 @@
+package lzss
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeaderRoundTrip(t *testing.T) {
+	assert := require.New(t)
+	h := Header{
+		Version: Version,
+		Level:   BestCompression,
+		Extra:   []byte("extra data"),
+	}
+
+	var buf bytes.Buffer
+	_, err := h.WriteTo(&buf)
+	assert.NoError(err)
+
+	var h2 Header
+	_, err = h2.ReadFrom(&buf)
+	assert.NoError(err)
+
+	assert.Equal(h, h2)
+}

--- a/lzss/header_test.go
+++ b/lzss/header_test.go
@@ -12,7 +12,6 @@ func TestHeaderRoundTrip(t *testing.T) {
 	h := Header{
 		Version: Version,
 		Level:   BestCompression,
-		Extra:   []byte("extra data"),
 	}
 
 	var buf bytes.Buffer

--- a/lzss/testdata/fuzz/FuzzCompress/03fb0e6c8a001815
+++ b/lzss/testdata/fuzz/FuzzCompress/03fb0e6c8a001815
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("\xff\xff0\xff1\xfd")
+[]byte("0")
+byte('\x11')

--- a/lzss/testdata/fuzz/FuzzCompress/1926a60304b8ca17
+++ b/lzss/testdata/fuzz/FuzzCompress/1926a60304b8ca17
@@ -1,0 +1,4 @@
+go test fuzz v1
+[]byte("\xff0")
+[]byte("0")
+byte('\x11')


### PR DESCRIPTION
This PR does:
1. Some code cleaning
2. `settings` is renamed to `Header` to be consistent with common compressor impl. `Header.Version` is now an `uint16` to be more future proof. 
3. `Compress(...)` takes an optional `hint` which is a previously compressed payload of part of the same input with same dict. That allows compressor to re-use the back references from the hint in workflows where we append data repeatedly. 