### PR TITLE
fix: headerBitLen constant

### DIFF
--- a/lzss/compress.go
+++ b/lzss/compress.go
@@ -41,7 +41,7 @@ const (
 )
 
 const (
-	bitLen = 16 // TODO @Tabaie document
+	headerBitLen = 24
 )
 
 // NewCompressor returns a new compressor with the given dictionary
@@ -232,7 +232,7 @@ func (compressor *Compressor) Compress(d []byte, hints ...[]byte) (c []byte, err
 		return nil, err
 	}
 
-	if compressor.buf.Len() >= len(d)+bitLen/8 {
+	if compressor.buf.Len() >= len(d)+headerBitLen/8 {
 		// compression was not worth it
 		compressor.buf.Reset()
 		header.Level = NoCompression

--- a/lzss/decompress.go
+++ b/lzss/decompress.go
@@ -90,7 +90,7 @@ func ReadIntoStream(data, dict []byte, level Level) (compress.Stream, error) {
 
 	// the main job of this function is to compute the right value for outLenBits
 	// so we can remove the extra zeros at the end of out
-	outLenBits := bitLen
+	outLenBits := headerBitLen
 	if header.Level == NoCompression {
 		return out, nil
 	}


### PR DESCRIPTION
The constant `bitLen` renamed to `headerBitLen` making its meaning clear, and assigned the correct value in light of the recent header size increase.