### PR TITLE
perf: Measure backref savings in bits rather than bytes

### DIFF
--- a/lzss/backref.go
+++ b/lzss/backref.go
@@ -74,5 +74,5 @@ func (b *backref) savings() int {
 	if b.length == -1 {
 		return math.MinInt // -1 is a special value
 	}
-	return b.length - b.bType.nbBytesBackRef
+	return 8*b.length - int(b.bType.NbBitsBackRef)
 }


### PR DESCRIPTION
The greater precision yields a very moderate improvement in the compression ratio