### PR TITLE
feat: FillBytes and ReadBytes functions

### DIFF
--- a/lzss/compress.go
+++ b/lzss/compress.go
@@ -335,7 +335,7 @@ func (compressor *Compressor) Stream() compress.Stream {
 	}
 
 	return compress.Stream{
-		D:       res.D[:(res.Len()-int(compressor.lastNbSkippedBits))/int(wordNbBits)],
+		D:       res.D[:res.Len()-(int(compressor.lastNbSkippedBits)/int(wordNbBits))],
 		NbSymbs: res.NbSymbs,
 	}
 }

--- a/lzss/compress.go
+++ b/lzss/compress.go
@@ -349,6 +349,9 @@ func (compressor *Compressor) Stream() compress.Stream {
 func (compressor *Compressor) SerializedStreamSize(nbBits int) int {
 	bitsPerWord := int(compressor.intendedLevel)
 	wordsForData := (compressor.outBuf.Len()*8 - int(compressor.nbSkippedBits)) / bitsPerWord
+	if compressor.level == NoCompression {
+		wordsForData = (compressor.inBuf.Len() + headerBitLen/8) * 8 / bitsPerWord
+	}
 	return compress.StreamSerializedSize(wordsForData, bitsPerWord, nbBits)
 }
 

--- a/lzss/compress.go
+++ b/lzss/compress.go
@@ -348,12 +348,8 @@ func (compressor *Compressor) Stream() compress.Stream {
 // SerializedStreamSize returns the size of the compressed stream, if it were to be serialized by the FillBytes method
 func (compressor *Compressor) SerializedStreamSize(nbBits int) int {
 	bitsPerWord := int(compressor.intendedLevel)
-	wordsPerElem := (nbBits + bitsPerWord - 1) / bitsPerWord
-	wordsForLen := (31 + bitsPerWord) / bitsPerWord
 	wordsForData := (compressor.outBuf.Len()*8 - int(compressor.nbSkippedBits)) / bitsPerWord
-	bytesPerElem := (nbBits + 7) / 8
-	nbElems := (wordsForLen + wordsForData + wordsPerElem - 1) / wordsPerElem
-	return nbElems * bytesPerElem
+	return compress.StreamSerializedSize(wordsForData, bitsPerWord, nbBits)
 }
 
 // Compress compresses the given data; if hint is provided, the compressor will try to use it

--- a/lzss/compress.go
+++ b/lzss/compress.go
@@ -345,14 +345,20 @@ func (compressor *Compressor) Stream() compress.Stream {
 	}
 }
 
-// SerializedStreamSize returns the size of the compressed stream, if it were to be serialized by the FillBytes method
-func (compressor *Compressor) SerializedStreamSize(nbBits int) int {
+func (compressor *Compressor) LenStream() int {
 	bitsPerWord := int(compressor.levelSetting)
 	wordsForData := (compressor.outBuf.Len()*8 - int(compressor.nbSkippedBits)) / bitsPerWord
 	if compressor.level == NoCompression {
 		wordsForData = (compressor.inBuf.Len() + headerBitLen/8) * 8 / bitsPerWord
 	}
-	return compress.StreamSerializedSize(wordsForData, bitsPerWord, nbBits)
+	return wordsForData
+}
+
+// SerializedStreamSize returns the size of the compressed stream, if it were to be serialized by the FillBytes method
+// TODO @tabaie remove this in favor of LenStream
+func (compressor *Compressor) SerializedStreamSize(nbBits int) int {
+	bitsPerWord := int(compressor.levelSetting)
+	return compress.StreamSerializedSize(compressor.LenStream(), bitsPerWord, nbBits)
 }
 
 // Compress compresses the given data; if hint is provided, the compressor will try to use it

--- a/lzss/compress_test.go
+++ b/lzss/compress_test.go
@@ -40,24 +40,6 @@ func TestNoCompression(t *testing.T) {
 	testCompressionRoundTrip(t, []byte{'h', 'i'})
 }
 
-func TestNoCompressionAttempt(t *testing.T) {
-
-	d := []byte{253, 254, 255}
-
-	compressor, err := NewCompressor(getDictionary(), NoCompression)
-	require.NoError(t, err)
-
-	c, err := compressor.Compress(d)
-	require.NoError(t, err)
-
-	dBack, err := Decompress(c, getDictionary())
-	require.NoError(t, err)
-
-	if !bytes.Equal(d, dBack) {
-		t.Fatal("round trip failed")
-	}
-}
-
 func Test9E(t *testing.T) {
 	testCompressionRoundTrip(t, []byte{1, 1, 1, 1, 2, 1, 1, 1, 1})
 }

--- a/lzss/compress_test.go
+++ b/lzss/compress_test.go
@@ -264,10 +264,10 @@ func TestAverageBatchWithSerialization(t *testing.T) {
 	assert.Equal(cStream, cStreamBack)
 
 	c := compressor.Bytes()
-	cBack := cStreamBack.ToBytes()
+	cBack := cStreamBack.ContentToBytes()
 	assert.True(bytes.Equal(c, cBack))
 
-	dataBack, err := Decompress(cStreamBack.ToBytes(), dict)
+	dataBack, err := Decompress(cStreamBack.ContentToBytes(), dict)
 	assert.NoError(err)
 
 	_ = dataBack

--- a/stream.go
+++ b/stream.go
@@ -98,7 +98,7 @@ func (s *Stream) FillBytes(bytes []byte, nbBits int) error {
 	var radix, elem big.Int // todo @tabaie all this big.Int business seems unnecessary. try using bitio instead?
 	radix.Lsh(big.NewInt(1), uint(bitsPerWord))
 
-	for i := 0; i < len(bytes); i += bytesPerElem {
+	for i := 0; i < len(bytes) && i*wordsPerElem < len(s.D); i += bytesPerElem {
 		elem.SetInt64(0)
 		for j := wordsPerElem - 1; j >= 0; j-- {
 			absJ := i*wordsPerElem + j

--- a/stream.go
+++ b/stream.go
@@ -99,7 +99,6 @@ func StreamSerializedSize(nbWords, wordNbBits, nbBits int) int {
 	wordsPerElem := (nbBits - 1) / wordNbBits
 	wordsForLen := (31 + wordNbBits) / wordNbBits
 	nbElems := (wordsForLen + nbWords + wordsPerElem - 1) / wordsPerElem
-	//fmt.Println("on input", nbWords, "words of", wordNbBits, "bits, we need", nbElems, "elements of", nbBits, "bits, or", bytesPerElem, "bytes per element")
 	return nbElems * bytesPerElem
 }
 
@@ -168,7 +167,7 @@ func (s *Stream) FillBytes(dst []byte, nbBits int) error {
 		}
 		w.TryWriteBits(0, rightPaddingBitsPerElem)
 
-		if w.TryAlign() != 0 { //TODO remove
+		if w.TryAlign() != 0 { //TODO redundant check if the algorithm works correctly. remove eventually
 			return errors.New("alignment error")
 		}
 	}
@@ -211,7 +210,6 @@ func (s *Stream) ReadBytes(src []byte, nbBits int) error {
 
 	w := bitio.NewReader(bytes.NewReader(src))
 
-	// todo uninterleave the reading of the number of words and the words themselves for cleaner code and to enable the ignoring of input past the final word
 	for i := 0; i < nbElems; i++ {
 		if w.TryReadBits(leftPaddingBitsPerElem) != 0 {
 			return errors.New("left padding not zero")

--- a/stream.go
+++ b/stream.go
@@ -58,10 +58,17 @@ func (s *Stream) BreakUp(nbSymbs int) Stream {
 }
 
 func (s *Stream) ToBytes(nbBits int) ([]byte, error) {
-	bitsPerWord := bitLen(s.NbSymbs)
-	res := make([]byte, (len(s.D)*bitsPerWord+7)/8+4)
+	res := make([]byte, StreamSerializedSize(len(s.D), bitLen(s.NbSymbs), nbBits))
 	err := s.FillBytes(res, nbBits)
 	return res, err
+}
+
+func StreamSerializedSize(nbWords, wordNbBits, nbBits int) int {
+	wordsPerElem := (nbBits + wordNbBits - 1) / wordNbBits
+	wordsForLen := (31 + wordNbBits) / wordNbBits
+	bytesPerElem := (nbBits + 7) / 8
+	nbElems := (wordsForLen + nbWords + wordsPerElem - 1) / wordsPerElem
+	return nbElems * bytesPerElem
 }
 
 type bytesWriter struct {

--- a/stream.go
+++ b/stream.go
@@ -316,16 +316,24 @@ func (s *Stream) Concat(a ...Stream) error {
 	_len := 0
 	for _, v := range a {
 		_len += len(v.D)
-		if v.NbSymbs != s.NbSymbs {
-			return errors.New("streams must have the same number of symbols")
-		}
+
 	}
 	if cap(s.D) < _len {
 		s.D = make([]int, 0, _len)
 	}
 	s.D = s.D[:0]
 	for _, v := range a {
-		s.D = append(s.D, v.D...)
+		if err := s.Append(v); err != nil {
+			return err
+		}
 	}
+	return nil
+}
+
+func (s *Stream) Append(a Stream) error {
+	if a.NbSymbs != s.NbSymbs {
+		return errors.New("streams must have the same number of symbols")
+	}
+	s.D = append(s.D, a.D...)
 	return nil
 }

--- a/stream.go
+++ b/stream.go
@@ -2,6 +2,8 @@ package compress
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
 	"hash"
 	"math/big"
 
@@ -58,6 +60,8 @@ func (s *Stream) BreakUp(nbSymbs int) Stream {
 	return Stream{d, nbSymbs}
 }
 
+// todo @tabaie too many copy pastes in the next three funcs
+
 func (s *Stream) Pack(nbBits int) []*big.Int {
 	wordLen := bitLen(s.NbSymbs)
 	wordsPerElem := (nbBits - 1) / wordLen
@@ -77,6 +81,80 @@ func (s *Stream) Pack(nbBits int) []*big.Int {
 		}
 	}
 	return packed
+}
+
+func (s *Stream) FillBytes(bytes []byte, nbBits int) error {
+	bitsPerWord := bitLen(s.NbSymbs)
+	wordsPerElem := (nbBits - 1) / bitsPerWord
+	bytesPerElem := (nbBits + 7) / 8
+
+	if len(bytes) < (len(s.D)*bitsPerWord+7)/8+4 {
+		return errors.New("not enough room in bytes")
+	}
+
+	binary.BigEndian.PutUint32(bytes[:4], uint32(len(s.D)))
+	bytes = bytes[4:]
+
+	var radix, elem big.Int // todo @tabaie all this big.Int business seems unnecessary. try using bitio instead?
+	radix.Lsh(big.NewInt(1), uint(bitsPerWord))
+
+	for i := 0; i < len(bytes); i += bytesPerElem {
+		elem.SetInt64(0)
+		for j := wordsPerElem - 1; j >= 0; j-- {
+			absJ := i*wordsPerElem + j
+			if absJ >= len(s.D) {
+				continue
+			}
+			elem.Mul(&elem, &radix).Add(&elem, big.NewInt(int64(s.D[absJ])))
+		}
+		elem.FillBytes(bytes[i : i+bytesPerElem])
+	}
+	return nil
+}
+
+func (s *Stream) ReadBytes(byts []byte, nbBits int) error {
+	bitsPerWord := bitLen(s.NbSymbs)
+
+	if s.NbSymbs != 1<<bitsPerWord {
+		return errors.New("only powers of 2 currently supported for NbSymbs")
+	}
+
+	s.resize(int(binary.BigEndian.Uint32(byts[:4])))
+	byts = byts[4:]
+
+	wordsPerElem := (nbBits - 1) / bitsPerWord
+	bytesPerElem := (nbBits + 7) / 8
+	nbElems := (len(s.D) + wordsPerElem - 1) / wordsPerElem
+
+	if len(byts) < nbElems*bytesPerElem {
+		return errors.New("not enough bytes")
+	}
+
+	w := bitio.NewReader(bytes.NewReader(byts))
+
+	for i := 0; i < nbElems; i++ {
+		w.TryReadBits(uint8(8*bytesPerElem - bitsPerWord*wordsPerElem))
+		if i+1 == nbElems {
+			wordsToRead := len(s.D) - i*wordsPerElem
+			w.TryReadBits(uint8((wordsPerElem - wordsToRead) * bitsPerWord)) // skip unused bits
+		}
+		for j := 0; j < wordsPerElem; j++ {
+			wordI := i*wordsPerElem + j
+			if wordI >= len(s.D) {
+				break
+			}
+			s.D[wordI] = int(w.TryReadBits(uint8(bitsPerWord)))
+		}
+	}
+
+	return w.TryError
+}
+
+func (s *Stream) resize(_len int) {
+	if len(s.D) < _len {
+		s.D = make([]int, _len)
+	}
+	s.D = s.D[:_len]
 }
 
 func log(x, base int) int {

--- a/stream.go
+++ b/stream.go
@@ -16,6 +16,7 @@ type Stream struct {
 	NbSymbs int
 }
 
+// Len is the number of words currently in the stream
 func (s *Stream) Len() int {
 	return len(s.D)
 }
@@ -85,6 +86,8 @@ func (s *Stream) BreakUp(nbSymbs int) Stream {
 	return Stream{d, nbSymbs}
 }
 
+// ToBytes does the same thing as FillBytes, but allocates a new byte slice for the purpose.
+// todo @tabaie across the repo, replace nbBits with a clearer name that is still doesn't mention algebra
 func (s *Stream) ToBytes(nbBits int) ([]byte, error) {
 	res := make([]byte, StreamSerializedSize(len(s.D), bitLen(s.NbSymbs), nbBits))
 	err := s.FillBytes(res, nbBits)
@@ -165,6 +168,10 @@ func (s *Stream) FillBytes(dst []byte, nbBits int) error {
 	}
 	w.TryAlign()
 	return w.TryError
+}
+
+func (s *Stream) ByteLen(nbBits int) int {
+	return StreamSerializedSize(len(s.D), bitLen(s.NbSymbs), nbBits)
 }
 
 // ReadBytes first reads elements of length nbBits in a byte-aligned manner, and then reads the elements into the stream

--- a/stream.go
+++ b/stream.go
@@ -64,9 +64,10 @@ func (s *Stream) ToBytes(nbBits int) ([]byte, error) {
 }
 
 func StreamSerializedSize(nbWords, wordNbBits, nbBits int) int {
-	wordsPerElem := (nbBits + wordNbBits - 1) / wordNbBits
 	wordsForLen := (31 + wordNbBits) / wordNbBits
 	bytesPerElem := (nbBits + 7) / 8
+	wordsPerElemHeadroom := (bytesPerElem*8 - nbBits + wordNbBits - 1) / wordNbBits
+	wordsPerElem := (nbBits+wordNbBits-1)/wordNbBits - wordsPerElemHeadroom
 	nbElems := (wordsForLen + nbWords + wordsPerElem - 1) / wordsPerElem
 	return nbElems * bytesPerElem
 }

--- a/stream.go
+++ b/stream.go
@@ -86,6 +86,11 @@ func (s *Stream) Pack(nbBits int) []*big.Int {
 // FillBytes aligns the stream first according to "field elements" of length nbBits, and then aligns the field elements to bytes
 func (s *Stream) FillBytes(bytes []byte, nbBits int) error {
 	bitsPerWord := bitLen(s.NbSymbs)
+
+	if bitsPerWord >= nbBits {
+		return errors.New("words do not fit in elements")
+	}
+
 	wordsPerElem := (nbBits - 1) / bitsPerWord
 	bytesPerElem := (nbBits + 7) / 8
 
@@ -118,6 +123,10 @@ func (s *Stream) FillBytes(bytes []byte, nbBits int) error {
 // ReadBytes first reads elements of length nbBits in a byte-aligned manner, and then reads the elements into the stream
 func (s *Stream) ReadBytes(bytes []byte, nbBits int) error {
 	bitsPerWord := bitLen(s.NbSymbs)
+
+	if bitsPerWord >= nbBits {
+		return errors.New("words do not fit in elements")
+	}
 
 	if s.NbSymbs != 1<<bitsPerWord {
 		return errors.New("only powers of 2 currently supported for NbSymbs")

--- a/stream.go
+++ b/stream.go
@@ -270,3 +270,25 @@ func (s *Stream) Unmarshal(b []byte) *Stream {
 
 	return s
 }
+
+// ToBytes writes the content of the stream to a byte slice, with no metadata about the size of the stream or the number of symbols.
+// it mainly serves testing purposes so in case of a write error it panics.
+func (s *Stream) ToBytes() []byte {
+	bitsPerWord := bitLen(s.NbSymbs)
+
+	nbBytes := (len(s.D)*bitsPerWord + 7) / 8
+	bb := bytesLib.NewBuffer(make([]byte, 0, nbBytes))
+
+	w := bitio.NewWriter(bb)
+	for i := range s.D {
+		w.TryWriteBits(uint64(s.D[i]), uint8(bitsPerWord))
+	}
+	if w.TryError != nil {
+		panic(w.TryError)
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+
+	return bb.Bytes()
+}

--- a/stream.go
+++ b/stream.go
@@ -276,3 +276,27 @@ func (s *Stream) ContentToBytes() []byte {
 
 	return bb.Bytes()
 }
+
+// Concat concatenates the streams into the current stream
+func (s *Stream) Concat(a ...Stream) error {
+	if len(a) == 0 {
+		s.D = nil
+		return nil
+	}
+
+	s.NbSymbs = a[0].NbSymbs
+	_len := 0
+	for _, v := range a {
+		_len += len(v.D)
+		if v.NbSymbs != s.NbSymbs {
+			return errors.New("streams must have the same number of symbols")
+		}
+	}
+	if cap(s.D) < _len {
+		s.D = make([]int, 0, _len)
+	}
+	for _, v := range a {
+		s.D = append(s.D, v.D...)
+	}
+	return nil
+}

--- a/stream.go
+++ b/stream.go
@@ -99,7 +99,7 @@ func (s *Stream) FillBytes(dst []byte, nbBits int) error {
 	bytesPerElem := (nbBits + 7) / 8
 	headroomBitsPerElem := uint8(bytesPerElem*8 - bitsPerWord*wordsPerElem)
 
-	if len(dst) < ((len(s.D)+wordsForNb)*bitsPerWord+7)/8 {
+	if len(dst) < StreamSerializedSize(len(s.D), bitsPerWord, nbBits) {
 		return errors.New("not enough room in dst")
 	}
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -18,12 +18,35 @@ func TestMarshalRoundTrip(t *testing.T) {
 	}
 }
 
+func TestFillBytesRoundTrip(t *testing.T) {
+	d := make([]int, 1000)
+	b := make([]byte, 10000)
+
+	for i := 0; i < 1000; i++ {
+		var s Stream
+		s.D = d[:rand.Intn(len(d))+1]       //#nosec G404 weak rng is fine here
+		s.NbSymbs = 1 << (rand.Intn(9) + 1) //#nosec G404 weak rng is fine here
+		fieldSize := 248 + rand.Intn(9)     //#nosec G404 weak rng is fine here
+		testFillBytes(t, b, fieldSize, s)
+	}
+}
+
 func testMarshal(t *testing.T, s Stream) {
 	fillRandom(s)
 	marshalled := s.Marshal()
 	sBack := Stream{NbSymbs: s.NbSymbs}
 	sBack.Unmarshal(marshalled)
 	assert.Equal(t, s, sBack, "marshalling round trip failed for nbSymbs %d and size %d", s.NbSymbs, len(s.D))
+}
+
+func testFillBytes(t *testing.T, b []byte, nbBits int, s Stream) {
+	fillRandom(s)
+
+	assert.NoError(t, s.FillBytes(b, nbBits))
+
+	sBack := Stream{NbSymbs: s.NbSymbs}
+	assert.NoError(t, sBack.ReadBytes(b, nbBits))
+	assert.Equal(t, s, sBack, "fill bytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
 }
 
 func fillRandom(s Stream) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -60,6 +60,17 @@ func TestChecksumSucceeds(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWriteNumRoundTrip(t *testing.T) {
+	s := Stream{NbSymbs: 16}
+	for i := 0; i < 1000; i++ {
+		s.D = s.D[:0]
+		n := randIntn(65536)
+		s.WriteNum(n, 4)
+		nBack := s.ReadNum(0, 4)
+		assert.Equal(t, n, nBack)
+	}
+}
+
 func testFillBytesArithmetic(t *testing.T, modulus *big.Int) {
 	modulusByteLen := (modulus.BitLen() + 7) / 8
 	n1, n2 := randIntn(1000)+1, randIntn(1000)+1 //#nosec G404 weak rng is fine here

--- a/stream_test.go
+++ b/stream_test.go
@@ -10,20 +10,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMarshalRoundTrip(t *testing.T) {
-	d := make([]int, 1000)
-	for i := 0; i < 1000; i++ {
-		var s Stream
-		s.D = d[:rand.Intn(len(d))+1]  //#nosec G404 weak rng is fine here
-		s.NbSymbs = rand.Intn(510) + 2 //#nosec G404 weak rng is fine here
-
-		testMarshal(t, s)
-	}
-}
-
 func TestFillBytesRoundTrip(t *testing.T) {
-	d := make([]int, 1000)
-	b := make([]byte, 10000)
+	d := make([]int, 2)
+	b := make([]byte, 100)
 
 	for i := 0; i < 1000; i++ {
 		var s Stream
@@ -32,14 +21,6 @@ func TestFillBytesRoundTrip(t *testing.T) {
 		fieldSize := 248 + rand.Intn(9)     //#nosec G404 weak rng is fine here
 		testFillBytes(t, b, fieldSize, s)
 	}
-}
-
-func testMarshal(t *testing.T, s Stream) {
-	fillRandom(s)
-	marshalled := s.Marshal()
-	sBack := Stream{NbSymbs: s.NbSymbs}
-	sBack.Unmarshal(marshalled)
-	assert.Equal(t, s, sBack, "marshalling round trip failed for nbSymbs %d and size %d", s.NbSymbs, len(s.D))
 }
 
 func TestFillBytesNotEnoughSpace(t *testing.T) {
@@ -88,7 +69,7 @@ func testFillBytesArithmetic(t *testing.T, modulus *big.Int) {
 
 	unpacked := Stream{NbSymbs: s.NbSymbs}
 	assert.NoError(t, unpacked.ReadBytes(packed, modulus.BitLen()))
-	b1Back := unpacked.ToBytes()
+	b1Back := unpacked.ContentToBytes()
 
 	assert.Equal(t, b1Back[:n1], b1)
 

--- a/stream_test.go
+++ b/stream_test.go
@@ -48,11 +48,8 @@ func TestFillBytesArithmeticBls12377(t *testing.T) {
 }
 
 func TestChecksumSucceeds(t *testing.T) {
-	d := make([]byte, 1024)
-	for i := 0; i < len(d)/2; i++ {
-		d[2*i] = byte(i/256) + 1
-		d[2*i+1] = byte(i)
-	}
+	d := make([]byte, 65536)
+	rand.Read(d) //#nosec G404 weak rng is fine here
 
 	s, err := NewStream(d, 8)
 	assert.NoError(t, err)

--- a/stream_test.go
+++ b/stream_test.go
@@ -5,8 +5,11 @@ import (
 	"crypto"
 	"crypto/rand"
 	"encoding/binary"
+	"fmt"
 	"github.com/stretchr/testify/require"
 	"math/big"
+	"os"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -14,16 +17,23 @@ import (
 )
 
 func TestFillBytesRoundTrip(t *testing.T) {
-	d := make([]int, 2)
+	//d := make([]int, 2)
+	var D [100]int
 	b := make([]byte, 100)
 
-	for i := 0; i < 1000; i++ {
-		var s Stream
-		s.D = d[:randIntn(len(d))+1]       //#nosec G404 weak rng is fine here
-		s.NbSymbs = 1 << (randIntn(9) + 1) //#nosec G404 weak rng is fine here
-		fieldSize := 248 + randIntn(9)     //#nosec G404 weak rng is fine here
-		testFillBytes(t, b, fieldSize, s)
+	for l := 23; l <= len(D); l++ {
+		d := D[:l]
+		fmt.Println("len", l)
+		for i := 0; i < 100000; i++ {
+			var s Stream
+			//s.D = d[:randIntn(len(d))+1]       //#nosec G404 weak rng is fine here
+			s.D = d
+			s.NbSymbs = 1 << (randIntn(9) + 1) //#nosec G404 weak rng is fine here
+			fieldSize := 248 + randIntn(9)     //#nosec G404 weak rng is fine here
+			testFillBytes(t, b, fieldSize, s)
+		}
 	}
+	l.f.Close()
 }
 
 func TestFillBytesNotEnoughSpace(t *testing.T) {
@@ -88,21 +98,75 @@ func testFillBytesArithmetic(t *testing.T, modulus *big.Int) {
 	assert.Equal(t, b1Back[:n1], b1)
 
 }
-func testFillBytes(t *testing.T, buffer []byte, nbBits int, s Stream) {
-	fillRandom(s)
 
+type logger struct {
+	f *os.File
+}
+
+var l = newLogger()
+
+func newLogger() logger {
+	f, err := os.OpenFile("log.txt", os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+	if err != nil {
+		panic(err)
+	}
+	return logger{f}
+}
+
+func (l logger) log(nbBits int, s Stream) {
+	b := fmt.Sprintf("testFillBytes(t, buffer[:], %d, Stream{NbSymbs: %d, D: []int{", nbBits, s.NbSymbs)
+	if _, err := l.f.WriteString(b); err != nil {
+		panic(err)
+	}
+	for i := range s.D {
+		b = strconv.Itoa(s.D[i])
+		if i != len(s.D)-1 {
+			b += ", "
+		}
+		if _, err := l.f.WriteString(b); err != nil {
+			panic(err)
+		}
+	}
+	if _, err := l.f.WriteString("}})\n"); err != nil {
+		panic(err)
+	}
+}
+
+var first = true
+
+func testFillBytes(t *testing.T, buffer []byte, nbBits int, s Stream) {
+
+	// todo remove
+	/*s = Stream{
+		D:       []int{508},
+		NbSymbs: 512,
+	}
+	nbBits = 255*/
+
+	if first {
+		//s.D = []int{0, 0, 0}
+		//fillRandom(s) // todo reintroduce
+		//first = false
+	}
+
+	l.log(nbBits, s)
+	//fmt.Println("nbBits", nbBits, "nbSymbs", s.NbSymbs, "slice", s.D)
+	//fmt.Printf("testFillBytes(t, buffer[:], %d, Stream{NbSymbs: %d, D: []int{%d}})\n", nbBits, s.NbSymbs, s.D[0])
 	require.NoError(t, s.FillBytes(buffer, nbBits))
 
 	sBack := Stream{NbSymbs: s.NbSymbs}
 	require.NoError(t, sBack.ReadBytes(buffer, nbBits))
 	require.Equal(t, s, sBack, "fill bytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
 
-	// test ToBytes
-	buffer, err := s.ToBytes(nbBits)
-	require.NoError(t, err)
+	/*	todo reintroduce
+		// test ToBytes
+		buffer, err := s.ToBytes(nbBits)
+		require.NoError(t, err)
 
-	require.NoError(t, sBack.ReadBytes(buffer, nbBits))
-	require.Equal(t, s, sBack, "ToBytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
+		require.NoError(t, sBack.ReadBytes(buffer, nbBits))
+		require.Equal(t, s, sBack, "ToBytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
+
+	*/
 }
 
 func fillRandom(s Stream) {
@@ -136,4 +200,13 @@ func randIntn(n int) int {
 	x := binary.LittleEndian.Uint64(randBuf[:])
 	randBufLock.Unlock()
 	return int(x % uint64(n)) // if n is small compared to 2^64, the result is close to uniform; not that it matters as this is only used for testing
+}
+
+func TestPaddingBug(t *testing.T) {
+	var buffer [2000]byte
+	/*testFillBytes(t, buffer[:], 249, Stream{NbSymbs: 512, D: []int{71}})
+	testFillBytes(t, buffer[:], 250, Stream{NbSymbs: 32, D: []int{17}})*/
+
+	testFillBytes(t, buffer[:], 250, Stream{NbSymbs: 512, D: []int{312, 224, 9, 27, 475, 146, 402, 227, 8, 46, 56, 53, 309, 216, 387, 219, 329, 502, 433, 204, 254, 82, 433}})
+	testFillBytes(t, buffer[:], 252, Stream{NbSymbs: 512, D: []int{372, 64, 279, 24, 122, 65, 78, 101, 130, 483, 313, 475, 325, 147, 67, 335, 229, 401, 87, 222, 277, 213, 505}})
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -48,13 +48,17 @@ func TestFillBytesArithmeticBls12377(t *testing.T) {
 }
 
 func TestChecksumSucceeds(t *testing.T) {
-	d := make([]byte, 65536)
-	rand.Read(d) //#nosec G404 weak rng is fine here
+	d := make([]byte, 1024)
+	for i := 0; i < len(d)/2; i++ {
+		d[2*i] = byte(i/256) + 1
+		d[2*i+1] = byte(i)
+	}
+
 	s, err := NewStream(d, 8)
 	assert.NoError(t, err)
 
 	_, err = s.Checksum(crypto.SHA256.New(), 253)
-	assert.Error(t, err)
+	assert.NoError(t, err)
 }
 
 func testFillBytesArithmetic(t *testing.T, modulus *big.Int) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,7 +1,9 @@
 package compress
 
 import (
+	"bytes"
 	"github.com/stretchr/testify/require"
+	"math/big"
 	"math/rand"
 	"testing"
 
@@ -50,6 +52,37 @@ func TestFillBytesNotEnoughSpace(t *testing.T) {
 	fillRandom(s)
 
 	assert.Error(t, s.FillBytes(data, 252))
+}
+
+func TestRoundTripPackFillBytesMarshalUnmarshalReadBytes(t *testing.T) {
+	// typical BlobMaker case;
+	// we have 2 slices of random bytes.
+	// we want to concatenate them in the blob, and pack them in such a way
+	// that len(packed) % 32 == 0, and that each [:32] byte subslice is a valid bls12377 fr element.
+	// independently, we want to be able to unmarshal the blob, and read the bytes back.
+	n1, n2 := rand.Intn(1000)+1, rand.Intn(1000)+1 //#nosec G404 weak rng is fine here
+	b1, b2 := make([]byte, n1), make([]byte, n2)
+
+	concat := bytes.Join([][]byte{b1, b2}, []byte{})
+	s, err := NewStream(concat, 8)
+	assert.NoError(t, err)
+
+	packed := make([]byte, 128*1024)
+	var modulus big.Int
+	modulus.SetString("12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001", 16)
+	assert.NoError(t, s.FillBytes(packed, modulus.BitLen()))
+
+	var x big.Int
+	for i := 0; i < len(packed); i += 32 {
+		x.SetBytes(packed[i : i+32])
+		assert.True(t, x.Cmp(&modulus) < 0)
+	}
+
+	unpacked := Stream{NbSymbs: s.NbSymbs}
+	assert.NoError(t, unpacked.ReadBytes(packed, modulus.BitLen()))
+	b1Back := unpacked.ToBytes()
+
+	assert.Equal(t, b1Back[:n1], b1)
 }
 
 func testFillBytes(t *testing.T, buffer []byte, nbBits int, s Stream) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -82,6 +82,13 @@ func testFillBytes(t *testing.T, buffer []byte, nbBits int, s Stream) {
 	sBack := Stream{NbSymbs: s.NbSymbs}
 	require.NoError(t, sBack.ReadBytes(buffer, nbBits))
 	require.Equal(t, s, sBack, "fill bytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
+
+	// test ToBytes
+	buffer, err := s.ToBytes(nbBits)
+	require.NoError(t, err)
+
+	require.NoError(t, sBack.ReadBytes(buffer, nbBits))
+	require.Equal(t, s, sBack, "ToBytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
 }
 
 func fillRandom(s Stream) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -62,7 +62,7 @@ func testFillBytesArithmetic(t *testing.T, modulus *big.Int) {
 	assert.NoError(t, s.FillBytes(packed, modulus.BitLen()))
 
 	var x big.Int
-	for i := 4; i+modulusByteLen <= len(packed); i += modulusByteLen {
+	for i := 0; i+modulusByteLen <= len(packed); i += modulusByteLen {
 		x.SetBytes(packed[i : i+modulusByteLen])
 		assert.True(t, x.Cmp(modulus) < 0)
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -2,6 +2,7 @@ package compress
 
 import (
 	"bytes"
+	"crypto"
 	"github.com/stretchr/testify/require"
 	"math/big"
 	"math/rand"
@@ -44,6 +45,16 @@ func TestFillBytesArithmeticBls12377(t *testing.T) {
 	var modulus big.Int
 	modulus.SetString("12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001", 16)
 	testFillBytesArithmetic(t, &modulus)
+}
+
+func TestChecksumSucceeds(t *testing.T) {
+	d := make([]byte, 65536)
+	rand.Read(d) //#nosec G404 weak rng is fine here
+	s, err := NewStream(d, 8)
+	assert.NoError(t, err)
+
+	_, err = s.Checksum(crypto.SHA256.New(), 253)
+	assert.Error(t, err)
 }
 
 func testFillBytesArithmetic(t *testing.T, modulus *big.Int) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -124,12 +124,16 @@ var (
 )
 
 // randIntn returns a random number in [0, n); substitute for the deprecated math/rand.Intn
+// panics if n <= 0
 func randIntn(n int) int {
+	if n <= 0 {
+		panic("randIntn: n <= 0")
+	}
 	randBufLock.Lock()
 	if _, err := rand.Read(randBuf[:]); err != nil {
 		panic(err)
 	}
-	res := int(binary.LittleEndian.Uint64(randBuf[:]) >> 1 << 1)
+	x := binary.LittleEndian.Uint64(randBuf[:])
 	randBufLock.Unlock()
-	return res % n // if n is small compared to 2^64, the result is close to uniform; not that it matters as this is only used for testing
+	return int(x % uint64(n)) // if n is small compared to 2^64, the result is close to uniform; not that it matters as this is only used for testing
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -54,7 +54,7 @@ func TestFillBytesNotEnoughSpace(t *testing.T) {
 	assert.Error(t, s.FillBytes(data, 252))
 }
 
-func TestRoundTripPackFillBytesMarshalUnmarshalReadBytesBls12377(t *testing.T) {
+func TestFillBytesArithmeticBls12377(t *testing.T) {
 	// typical BlobMaker case;
 	// we have 2 slices of random bytes.
 	// we want to concatenate them in the blob, and pack them in such a way
@@ -62,10 +62,10 @@ func TestRoundTripPackFillBytesMarshalUnmarshalReadBytesBls12377(t *testing.T) {
 	// independently, we want to be able to unmarshal the blob, and read the bytes back.
 	var modulus big.Int
 	modulus.SetString("12ab655e9a2ca55660b44d1e5c37b00159aa76fed00000010a11800000000001", 16)
-	testRoundTripPackFillBytesMarshalUnmarshalReadBytes(t, &modulus)
+	testFillBytesArithmetic(t, &modulus)
 }
 
-func testRoundTripPackFillBytesMarshalUnmarshalReadBytes(t *testing.T, modulus *big.Int) {
+func testFillBytesArithmetic(t *testing.T, modulus *big.Int) {
 	modulusByteLen := (modulus.BitLen() + 7) / 8
 	n1, n2 := rand.Intn(1000)+1, rand.Intn(1000)+1 //#nosec G404 weak rng is fine here
 	b1, b2 := make([]byte, n1), make([]byte, n2)

--- a/stream_test.go
+++ b/stream_test.go
@@ -18,18 +18,22 @@ import (
 
 func TestFillBytesRoundTrip(t *testing.T) {
 	//d := make([]int, 2)
-	var D [100]int
-	b := make([]byte, 100)
+	var D [85]int
+	b := make([]byte, 100000000)
 
-	for l := 23; l <= len(D); l++ {
+	for l := 85; l <= len(D); l++ {
 		d := D[:l]
 		fmt.Println("len", l)
-		for i := 0; i < 100000; i++ {
+		for i := 0; i < 1000; i++ {
+			if i%100 == 0 {
+				fmt.Println("\t", i)
+			}
+
 			var s Stream
 			//s.D = d[:randIntn(len(d))+1]       //#nosec G404 weak rng is fine here
 			s.D = d
-			s.NbSymbs = 1 << (randIntn(9) + 1) //#nosec G404 weak rng is fine here
-			fieldSize := 248 + randIntn(9)     //#nosec G404 weak rng is fine here
+			s.NbSymbs = 1 << (randIntn(2) + 1) //#nosec G404 weak rng is fine here
+			fieldSize := 3 + randIntn(9)       //#nosec G404 weak rng is fine here
 			testFillBytes(t, b, fieldSize, s)
 		}
 	}
@@ -149,24 +153,24 @@ func testFillBytes(t *testing.T, buffer []byte, nbBits int, s Stream) {
 		//first = false
 	}
 
-	l.log(nbBits, s)
+	//l.log(nbBits, s)
 	//fmt.Println("nbBits", nbBits, "nbSymbs", s.NbSymbs, "slice", s.D)
 	//fmt.Printf("testFillBytes(t, buffer[:], %d, Stream{NbSymbs: %d, D: []int{%d}})\n", nbBits, s.NbSymbs, s.D[0])
-	require.NoError(t, s.FillBytes(buffer, nbBits))
 
 	sBack := Stream{NbSymbs: s.NbSymbs}
+
+	// todo reintroduce
+	require.NoError(t, s.FillBytes(buffer, nbBits))
+
 	require.NoError(t, sBack.ReadBytes(buffer, nbBits))
 	require.Equal(t, s, sBack, "fill bytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
 
-	/*	todo reintroduce
-		// test ToBytes
-		buffer, err := s.ToBytes(nbBits)
-		require.NoError(t, err)
+	// test ToBytes
+	buffer, err := s.ToBytes(nbBits)
+	require.NoError(t, err, "failure at length %d", len(s.D))
 
-		require.NoError(t, sBack.ReadBytes(buffer, nbBits))
-		require.Equal(t, s, sBack, "ToBytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
-
-	*/
+	require.NoError(t, sBack.ReadBytes(buffer, nbBits))
+	require.Equal(t, s, sBack, "ToBytes round trip failed for nbSymbs %d, size %d and field size %d", s.NbSymbs, len(s.D), nbBits)
 }
 
 func fillRandom(s Stream) {
@@ -204,9 +208,20 @@ func randIntn(n int) int {
 
 func TestPaddingBug(t *testing.T) {
 	var buffer [2000]byte
-	/*testFillBytes(t, buffer[:], 249, Stream{NbSymbs: 512, D: []int{71}})
-	testFillBytes(t, buffer[:], 250, Stream{NbSymbs: 32, D: []int{17}})*/
+
+	testFillBytes(t, buffer[:], 4, Stream{NbSymbs: 4, D: []int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}})
+
+	testFillBytes(t, buffer[:], 3, Stream{NbSymbs: 4, D: []int{3, 3, 1, 0, 3, 2, 3, 3, 1, 3, 1, 2, 0, 3, 0, 0, 0, 1, 0, 2, 2, 1, 0, 2, 3, 0, 3, 2, 1, 2, 0, 3, 2, 3, 0, 1, 2, 0, 0, 1, 3, 1, 0, 3, 0, 3, 1, 2, 3, 3, 1, 2, 2, 0, 0, 2, 2, 2, 2, 3, 3, 0, 0, 0, 3, 1, 2, 2, 0, 0, 1, 2, 1, 1, 3, 1, 2, 1, 3, 3, 3, 2, 1, 0, 2}})
+
+	testFillBytes(t, buffer[:], 6, Stream{NbSymbs: 4, D: []int{2}})
+
+	testFillBytes(t, buffer[:], 249, Stream{NbSymbs: 512, D: []int{71}})
+	testFillBytes(t, buffer[:], 250, Stream{NbSymbs: 32, D: []int{17}})
 
 	testFillBytes(t, buffer[:], 250, Stream{NbSymbs: 512, D: []int{312, 224, 9, 27, 475, 146, 402, 227, 8, 46, 56, 53, 309, 216, 387, 219, 329, 502, 433, 204, 254, 82, 433}})
 	testFillBytes(t, buffer[:], 252, Stream{NbSymbs: 512, D: []int{372, 64, 279, 24, 122, 65, 78, 101, 130, 483, 313, 475, 325, 147, 67, 335, 229, 401, 87, 222, 277, 213, 505}})
+
+	testFillBytes(t, buffer[:], 252, Stream{NbSymbs: 512, D: []int{461, 93, 293, 118, 74, 249, 387, 259, 176, 371, 495, 18, 237, 32, 36, 430, 486, 392, 201, 359, 443, 298, 425, 6}})
+
+	testFillBytes(t, buffer[:], 4, Stream{NbSymbs: 4, D: []int{2}})
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -17,25 +17,15 @@ import (
 )
 
 func TestFillBytesRoundTrip(t *testing.T) {
-	//d := make([]int, 2)
-	var D [85]int
-	b := make([]byte, 100000000)
+	var D [100]int
+	b := make([]byte, 100000)
 
-	for l := 85; l <= len(D); l++ {
-		d := D[:l]
-		fmt.Println("len", l)
-		for i := 0; i < 1000; i++ {
-			if i%100 == 0 {
-				fmt.Println("\t", i)
-			}
-
-			var s Stream
-			//s.D = d[:randIntn(len(d))+1]       //#nosec G404 weak rng is fine here
-			s.D = d
-			s.NbSymbs = 1 << (randIntn(2) + 1) //#nosec G404 weak rng is fine here
-			fieldSize := 3 + randIntn(9)       //#nosec G404 weak rng is fine here
-			testFillBytes(t, b, fieldSize, s)
-		}
+	for i := 0; i < 100000; i++ {
+		var s Stream
+		s.D = D[:randIntn(len(D))+1]       //#nosec G404 weak rng is fine here
+		s.NbSymbs = 1 << (randIntn(2) + 1) //#nosec G404 weak rng is fine here
+		fieldSize := 3 + randIntn(9)       //#nosec G404 weak rng is fine here
+		testFillBytes(t, b, fieldSize, s)
 	}
 	l.f.Close()
 }


### PR DESCRIPTION
As per https://github.com/Consensys/zkevm-monorepo/issues/2159, this PR provides the functions `FillBytes` and `ReadBytes` that pack the stream into field elements and then the field elements into given byte arrays.
