### PR TITLE
Feat/compressed size estimator

### DIFF
--- a/lzss/backref.go
+++ b/lzss/backref.go
@@ -49,14 +49,14 @@ type backref struct {
 
 // Warning; writeTo and readFrom are not symmetrical
 
-func (b *backref) writeTo(w *bitio.Writer, i int) {
-	w.TryWriteByte(b.bType.Delimiter)
-	w.TryWriteBits(uint64(b.length-1), b.bType.NbBitsLength)
+func (b *backref) writeTo(w bitWriter, i int) {
+	w.tryWriteByte(b.bType.Delimiter)
+	w.tryWriteBits(uint64(b.length-1), b.bType.NbBitsLength)
 	addrToWrite := b.address
 	if !b.bType.dictOnly {
 		addrToWrite = i - b.address - 1
 	}
-	w.TryWriteBits(uint64(addrToWrite), b.bType.NbBitsAddress)
+	w.tryWriteBits(uint64(addrToWrite), b.bType.NbBitsAddress)
 }
 
 func (b *backref) readFrom(r *bitio.Reader) {

--- a/lzss/compress_test.go
+++ b/lzss/compress_test.go
@@ -101,7 +101,7 @@ func FuzzCompress(f *testing.F) {
 			}
 		}
 
-		// test compress (i.e write all the bytes)
+		// test compress (i.e Write all the bytes)
 		compressor, err := NewCompressor(dict, level)
 		if err != nil {
 			t.Fatal(err)
@@ -113,7 +113,7 @@ func FuzzCompress(f *testing.F) {
 
 		checkDecompressResult(compressedBytes)
 
-		// test write byte by byte
+		// test Write byte by byte
 		compressor, err = NewCompressor(dict, level)
 		if err != nil {
 			t.Fatal(err)
@@ -125,7 +125,7 @@ func FuzzCompress(f *testing.F) {
 		}
 		checkDecompressResult(compressor.Bytes())
 
-		// test write byte by byte with revert
+		// test Write byte by byte with revert
 		compressor, err = NewCompressor(dict, level)
 		if err != nil {
 			t.Fatal(err)
@@ -139,7 +139,7 @@ func FuzzCompress(f *testing.F) {
 			}
 		}
 
-		// test write byte by byte with revert and write again
+		// test Write byte by byte with revert and Write again
 		compressor, err = NewCompressor(dict, level)
 		if err != nil {
 			t.Fatal(err)
@@ -168,22 +168,22 @@ func FuzzCompress(f *testing.F) {
 		if len(input) > 1 {
 			compressor.Reset()
 
-			// write all but the last byte
+			// Write all but the last byte
 			if _, err := compressor.Write(input[:len(input)-1]); err != nil {
 				t.Fatal(err)
 			}
-			// write the last byte
+			// Write the last byte
 			if _, err := compressor.Write([]byte{input[len(input)-1]}); err != nil {
 				t.Fatal(err)
 			}
 			checkDecompressResult(compressor.Bytes())
 
 			compressor.Reset()
-			// write the first byte
+			// Write the first byte
 			if _, err := compressor.Write([]byte{input[0]}); err != nil {
 				t.Fatal(err)
 			}
-			// write the rest
+			// Write the rest
 			if _, err := compressor.Write(input[1:]); err != nil {
 				t.Fatal(err)
 			}

--- a/lzss/decompress.go
+++ b/lzss/decompress.go
@@ -39,8 +39,8 @@ func Decompress(data, dict []byte) (d []byte, err error) {
 	var out bytes.Buffer
 	out.Grow(len(data) * 7)
 
-	// read byte per byte; if it's a backref, write the corresponding bytes
-	// otherwise, write the byte as is
+	// read byte per byte; if it's a backref, Write the corresponding bytes
+	// otherwise, Write the byte as is
 	s := in.TryReadByte()
 	for in.TryError == nil {
 		switch s {
@@ -155,8 +155,8 @@ func CompressedStreamInfo(c, dict []byte) (CompressionPhrases, error) {
 		inI += int(b.bType.NbBitsBackRef)
 	}
 
-	// read byte per byte; if it's a backref, write the corresponding bytes
-	// otherwise, write the byte as is
+	// read byte per byte; if it's a backref, Write the corresponding bytes
+	// otherwise, Write the byte as is
 	s := in.TryReadByte()
 	for in.TryError == nil {
 		switch s {

--- a/lzss/io.go
+++ b/lzss/io.go
@@ -1,0 +1,87 @@
+package lzss
+
+import (
+	"bytes"
+	"github.com/icza/bitio"
+	"io"
+)
+
+// writer aliases
+
+type bitWriter interface {
+	io.Writer
+	startSession() error
+	tryWriteBits(v uint64, nbBits uint8)
+	tryWriteByte(b byte)
+	tryError() error
+	endSession() error
+	reset()
+	bytes() []byte
+	len() int
+	revert()
+}
+
+type writer struct { // standard output writer for the compressor; capable of reverting
+	bb                bytes.Buffer
+	bw                *bitio.Writer // invariant: bw cache must always be empty
+	nbSkippedBits     uint8
+	lastOutLen        int
+	lastNbSkippedBits uint8
+}
+
+func (w *writer) startSession() error {
+	w.lastOutLen = w.len()
+	lastByte := w.bb.Bytes()[w.bb.Len()-1] // TODO change to   [w.lastOutLen-1]
+	w.bb.Truncate(w.bb.Len() - 1)
+	lastByte >>= w.nbSkippedBits
+	w.lastNbSkippedBits = w.nbSkippedBits
+	return w.bw.WriteBits(uint64(lastByte), 8-w.nbSkippedBits)
+}
+
+func (w *writer) Write(d []byte) (n int, err error) {
+	return w.bb.Write(d)
+}
+
+func (w *writer) len() int {
+	return w.bb.Len()
+}
+
+func (w *writer) tryWriteBits(v uint64, nbBits uint8) {
+	w.bw.TryWriteBits(v, nbBits)
+}
+
+func (w *writer) tryWriteByte(b byte) {
+	w.bw.TryWriteByte(b)
+}
+
+func (w *writer) tryError() error {
+	return w.bw.TryError
+}
+
+func (w *writer) endSession() (err error) {
+	w.nbSkippedBits, err = w.bw.Align()
+	return
+}
+
+func (w *writer) reset() {
+	w.bb.Reset()
+	w.nbSkippedBits = 0
+	w.lastOutLen = 0
+	w.lastNbSkippedBits = 0
+}
+
+func (w *writer) bytes() []byte {
+	return w.bb.Bytes()
+}
+
+func (w *writer) revert() {
+	w.bb.Truncate(w.lastOutLen)
+	w.nbSkippedBits = w.lastNbSkippedBits
+}
+
+func newBitWriter(size int) *writer {
+	var res writer
+	res.bb.Grow(size)
+	res.bw = bitio.NewWriter(&res.bb)
+	return &res
+}

--- a/lzss/io.go
+++ b/lzss/io.go
@@ -85,3 +85,44 @@ func newBitWriter(size int) *writer {
 	res.bw = bitio.NewWriter(&res.bb)
 	return &res
 }
+
+type bitCounter struct {
+	nbBits uint64
+}
+
+func (b *bitCounter) Write(p []byte) (n int, err error) {
+	b.nbBits += uint64(len(p)) * 8
+	return len(p), nil
+}
+
+func (b *bitCounter) startSession() error { return nil }
+
+func (b *bitCounter) tryWriteBits(v uint64, nbBits uint8) {
+	b.nbBits += uint64(nbBits)
+}
+
+func (b *bitCounter) tryWriteByte(_b byte) {
+	b.nbBits += 8
+}
+
+func (b *bitCounter) tryError() error { return nil }
+
+func (b *bitCounter) endSession() error {
+	return nil
+}
+
+func (b *bitCounter) reset() {
+	b.nbBits = 0
+}
+
+func (b *bitCounter) bytes() []byte {
+	panic("not available")
+}
+
+func (b *bitCounter) len() int {
+	return int((b.nbBits + 7) / 8)
+}
+
+func (b *bitCounter) revert() {
+	panic("not available")
+}

--- a/lzss/length_estimator.go
+++ b/lzss/length_estimator.go
@@ -1,0 +1,51 @@
+package lzss
+
+import "sync"
+
+type LengthEstimator struct {
+	// pool of compressors
+	poolLock    sync.Mutex
+	compressors []*Compressor
+
+	// common data
+	dict  []byte
+	level Level
+}
+
+func NewLengthEstimator(dict []byte, level Level) *LengthEstimator {
+	return &LengthEstimator{
+		dict:  dict,
+		level: level,
+	}
+}
+
+func (le *LengthEstimator) EstimateLength(data []byte) (int, error) {
+	// get a compressor
+	c, err := le.getCompressor()
+	if err != nil {
+		return 0, err
+	}
+	defer le.freeCompressor(c)
+
+	// "compress" the data
+	_, err = c.Write(data)
+	return c.Len(), err
+}
+
+func (le *LengthEstimator) getCompressor() (*Compressor, error) {
+	le.poolLock.Lock()
+	defer le.poolLock.Unlock()
+	if len(le.compressors) == 0 {
+		return newCompressor(le.dict, le.level, &bitCounter{})
+	}
+	c := le.compressors[len(le.compressors)-1]
+	le.compressors = le.compressors[:len(le.compressors)-1]
+	return c, nil
+}
+
+func (le *LengthEstimator) freeCompressor(c *Compressor) {
+	c.Reset()
+	le.poolLock.Lock()
+	defer le.poolLock.Unlock()
+	le.compressors = append(le.compressors, c)
+}


### PR DESCRIPTION
Introduces the thread-safe `LengthEstimator`, which consists of a pool of reusable compressors using "fake" bit writers, which only count the size of what is to be written to them.