### PR TITLE
Larger Long Backrefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,21 +41,20 @@ The compressed output is structured as follows:
 * `NOC` is a byte-represented boolean number indicating if compression has been bypassed entirely. `0x01` indicates no compression at all, whereby `PHRASES` will consist of a literal copy of the data. The only other acceptable value is `0x00`.
 * A compressor `PHRASE` is one of the following:
   - A byte, less than 254, to be interpreted as a literal.
-  - A fixed-length back-reference: (Note: from here-on data are represented with bit-level precision)
+  - A short back-reference: (Note: from here-on data are represented with bit-level precision)
     ```
-              0..7  8..15       16..30
+              0..7  8..15       16..29
             +------+------+----------------+
             | 0xFE | LEN  |     OFFSET     |
             +------+------+----------------+
     ```
-  - A dynamic-length back-reference:
+  - A long back-reference:
     ```
-              0..7  8..15   16..16+NBBITS_DYN_OFS
-            +------+------+------------------------+
-            | 0xFD | LEN  |        OFFSET          |
-            +------+------+------------------------+
+              0..7  8..15    16..36
+            +------+------+----------+
+            | 0xFD | LEN  |  OFFSET  |
+            +------+------+----------+
     ```
-    , where `NBBITS_DYN_OFS = ⌈log₂(N+DICT_SIZE)⌉`. The value `N` is the size in bytes of the output stream at the time the back-reference is being read, and `DICT_SIZE` is the size of the dictionary in bytes.
 
 ### Interpreting back-references
 A **back-reference** is an imperative to copy from already decompressed data. The "offset" field indicates how far back in the decompressed data to copy from, and the "length" field indicates how many bytes to copy. A back-reference may overlap with its own output, to create so-called "run length encodings", where many copies of the same byte are represented by a single back-reference. Whenever the computed index `i` of a byte to copy turns out negative, it is interpreted as the byte at index `DICT_SIZE + i` in the dictionary.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/consensys/compress
 
-go 1.20
+go 1.21
 
 require (
 	github.com/icza/bitio v1.1.0

--- a/lzss/backref.go
+++ b/lzss/backref.go
@@ -35,7 +35,7 @@ func NewShortBackrefType() (short BackrefType) {
 }
 
 func NewDynamicBackrefType(dictLen, addressableBytes int) (dynamic BackrefType) {
-	bound := uint8(20)
+	bound := uint8(21)
 	return newBackRefType(SymbolDynamic, bound, maxBackrefLenLog2, dictLen)
 }
 

--- a/lzss/regress_test.go
+++ b/lzss/regress_test.go
@@ -18,7 +18,7 @@ var refValues = map[string]refValue{
 		lzssRatio: 4.19,
 	},
 	"./testdata/blobs/1-goerli-3690632": {
-		lzssRatio: 24.10,
+		lzssRatio: 23.81,
 	},
 	"./testdata/blobs/2-1865938": {
 		lzssRatio: 3.73,
@@ -27,7 +27,7 @@ var refValues = map[string]refValue{
 		lzssRatio: 3.55,
 	},
 	"./testdata/blobs/5-1128897": {
-		lzssRatio: 7.26,
+		lzssRatio: 7.17,
 	},
 }
 


### PR DESCRIPTION
TL;DR: To make all of the dictionary accessible from 1984 KB into the stream. Improved worst case performance.