### PR TITLE
Add dependabot configuration for GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+
+updates:
+  # 1) GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /            # GitHub scans .github/workflows from here
+    schedule:
+      interval: weekly
+      day: monday
+      time: "03:00"
+    open-pull-requests-limit: 5
+    assignees: ["Tabaie", "gbotrel", "macfarla"]
+    labels: ["dependencies", "github-actions"]
+    commit-message:
+      prefix: "deps(actions)"
+      include: "scope"
+    groups:
+      core-actions-minor-patch:
+        update-types: ["minor", "patch"]
+        patterns:
+          - "actions/*"
+          - "github/*"
+      third-party-actions-minor-patch:
+        update-types: ["minor", "patch"]
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "actions/*"
+          - "github/*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add dependabot configuration for GitHub Actions updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Dependabot configuration for GitHub Actions updates in `.github/dependabot.yml`.
> 
> - Schedules weekly checks (Monday 03:00) with up to 5 open PRs, assigns `Tabaie`, `gbotrel`, `macfarla`, labels `dependencies` and `github-actions`
> - Groups minor/patch updates: `core-actions-minor-patch` for `actions/*` and `github/*`, and `third-party-actions-minor-patch` for all others (excluding core patterns)
> - Sets commit message prefix `deps(actions)` with scope and enforces a 7-day cooldown between PRs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 673ffedc88ede9eee24750b6d2fb1477f8fcd85e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->